### PR TITLE
Use Drag and Drop for Deposits

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -1,10 +1,10 @@
 
 function atm.ensure_init(name)
-   -- Ensure the atm account for the placer specified by name exists
-   atm.readaccounts()
-   if not atm.balance[name] then
-      atm.balance[name] = atm.startbalance
-   end
+	-- Ensure the atm account for the placer specified by name exists
+	atm.readaccounts()
+	if not atm.balance[name] then
+		atm.balance[name] = atm.startbalance
+	end
 end
 
 

--- a/forms.lua
+++ b/forms.lua
@@ -43,21 +43,36 @@ function atm.showform (player)
 	"label[8.5,0.75;10s]" ..
 	"label[9.5,0.75;50s]" ..
 	"label[10.5,0.75;100s]" ..
-	"item_image_button[6.5,1.25;1,1;".. "currency:minegeld" ..";i-1;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[7.5,1.25;1,1;".. "currency:minegeld_5" ..";i-5;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[8.5,1.25;1,1;".. "currency:minegeld_10" ..";i-10;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[9.5,1.25;1,1;".. "currency:minegeld_50" ..";i-50;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[10.5,1.25;1,1;".. "currency:minegeld_100" ..";i-100;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[6.5,2.25;1,1;".. "currency:minegeld" ..";t-10;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[7.5,2.25;1,1;".. "currency:minegeld_5" ..";t-50;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[8.5,2.25;1,1;".. "currency:minegeld_10" ..";t-100;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[9.5,2.25;1,1;".. "currency:minegeld_50" ..";t-500;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[10.5,2.25;1,1;".. "currency:minegeld_100" ..";t-1000;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[6.5,3.25;1,1;".. "currency:minegeld" ..";c-100;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[7.5,3.25;1,1;".. "currency:minegeld_5" ..";c-500;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[8.5,3.25;1,1;".. "currency:minegeld_10" ..";c-1000;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[9.5,3.25;1,1;".. "currency:minegeld_50" ..";c-5000;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[10.5,3.25;1,1;".. "currency:minegeld_100" ..";c-10000;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[6.5,1.25;1,1;".. "currency:minegeld" ..";i-1;]" ..
+	"label[6.55,1.75;x1]" ..
+	"item_image_button[7.5,1.25;1,1;".. "currency:minegeld_5" ..";i-5;]" ..
+	"label[7.55,1.75;x1]" ..
+	"item_image_button[8.5,1.25;1,1;".. "currency:minegeld_10" ..";i-10;]" ..
+	"label[8.55,1.75;x1]" ..
+	"item_image_button[9.5,1.25;1,1;".. "currency:minegeld_50" ..";i-50;]" ..
+	"label[9.55,1.75;x1]" ..
+	"item_image_button[10.5,1.25;1,1;".. "currency:minegeld_100" ..";i-100;]" ..
+	"label[10.55,1.75;x1]" ..
+	"item_image_button[6.5,2.25;1,1;".. "currency:minegeld" ..";t-10;]" ..
+	"label[6.55,2.75;x10]" ..
+	"item_image_button[7.5,2.25;1,1;".. "currency:minegeld_5" ..";t-50;]" ..
+	"label[7.55,2.75;x10]" ..
+	"item_image_button[8.5,2.25;1,1;".. "currency:minegeld_10" ..";t-100;]" ..
+	"label[8.55,2.75;x10]" ..
+	"item_image_button[9.5,2.25;1,1;".. "currency:minegeld_50" ..";t-500;]" ..
+	"label[9.55,2.75;x10]" ..
+	"item_image_button[10.5,2.25;1,1;".. "currency:minegeld_100" ..";t-1000;]" ..
+	"label[10.55,2.75;x10]" ..
+	"item_image_button[6.5,3.25;1,1;".. "currency:minegeld" ..";c-100;]" ..
+	"label[6.55,3.75;x100]" ..
+	"item_image_button[7.5,3.25;1,1;".. "currency:minegeld_5" ..";c-500;]" ..
+	"label[7.55,3.75;x100]" ..
+	"item_image_button[8.5,3.25;1,1;".. "currency:minegeld_10" ..";c-1000;]" ..
+	"label[8.55,3.75;x100]" ..
+	"item_image_button[9.5,3.25;1,1;".. "currency:minegeld_50" ..";c-5000;]" ..
+	"label[9.55,3.75;x100]" ..
+	"item_image_button[10.5,3.25;1,1;".. "currency:minegeld_100" ..";c-10000;]" ..
+	"label[10.55,3.75;x100]" ..
 	"button_exit[5.5,3;1,2;Quit;Quit]" ..
 	"list[current_player;main;2,4.5;8,1;]"..
 	"list[current_player;main;2,5.75;8,3;8]"..

--- a/forms.lua
+++ b/forms.lua
@@ -1,5 +1,32 @@
 -- atm interface
 
+local registered_currencies = {
+	["currency:minegeld"] = 1,
+	["currency:minegeld_5"] = 5,
+	["currency:minegeld_10"] = 10,
+	["currency:minegeld_50"] = 50,
+	["currency:minegeld_100"] = 100,
+}
+
+local deposit = core.create_detached_inventory("atm", {
+	allow_put = function(inv, listname, index, stack, player)
+		local multiplier = registered_currencies[stack:get_name()]
+		if multiplier then
+			local pname = player:get_player_name()
+			atm.balance[pname] = atm.balance[pname] + (multiplier * stack:get_count())
+			atm.saveaccounts()
+			-- refresh formspec
+			atm.showform(player)
+
+			return -1
+		end
+
+		return 0
+	end,
+})
+deposit:set_size("deposit", 1)
+
+
 function atm.showform (player)
 	atm.ensure_init(player:get_player_name())
 	local formspec =
@@ -9,42 +36,23 @@ function atm.showform (player)
 	default.gui_slots..
 	"label[0.5,0;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
 	"label[0.5,0.35;Deposit:]" ..
-	"label[0.5,0.75;1s]" ..
-	"label[1.5,0.75;5s]" ..
-	"label[2.5,0.75;10s]" ..
-	"label[3.5,0.75;50s]" ..
-	"label[4.5,0.75;100s]" ..
+	"list[detached:atm;deposit;0.5,1.25;1,1;0]" ..
 	"label[6.5,0.35;Withdraw:]" ..
 	"label[6.5,0.75;1s]" ..
 	"label[7.5,0.75;5s]" ..
 	"label[8.5,0.75;10s]" ..
 	"label[9.5,0.75;50s]" ..
 	"label[10.5,0.75;100s]" ..
-	"item_image_button[0.5,1.25;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[1.5,1.25;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[2.5,1.25;1,1;".. "currency:minegeld_10" ..";i10;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[3.5,1.25;1,1;".. "currency:minegeld_50" ..";i50;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[4.5,1.25;1,1;".. "currency:minegeld_100" ..";i100;\n\n\b\b\b\b\b" .. "x1" .."]" ..
 	"item_image_button[6.5,1.25;1,1;".. "currency:minegeld" ..";i-1;\n\n\b\b\b\b\b" .. "x1" .."]" ..
 	"item_image_button[7.5,1.25;1,1;".. "currency:minegeld_5" ..";i-5;\n\n\b\b\b\b\b" .. "x1" .."]" ..
 	"item_image_button[8.5,1.25;1,1;".. "currency:minegeld_10" ..";i-10;\n\n\b\b\b\b\b" .. "x1" .."]" ..
 	"item_image_button[9.5,1.25;1,1;".. "currency:minegeld_50" ..";i-50;\n\n\b\b\b\b\b" .. "x1" .."]" ..
 	"item_image_button[10.5,1.25;1,1;".. "currency:minegeld_100" ..";i-100;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-	"item_image_button[0.5,2.25;1,1;".. "currency:minegeld" ..";t10;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[1.5,2.25;1,1;".. "currency:minegeld_5" ..";t50;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[2.5,2.25;1,1;".. "currency:minegeld_10" ..";t100;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[3.5,2.25;1,1;".. "currency:minegeld_50" ..";t500;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[4.5,2.25;1,1;".. "currency:minegeld_100" ..";t1000;\n\n\b\b\b\b" .. "x10" .."]" ..
 	"item_image_button[6.5,2.25;1,1;".. "currency:minegeld" ..";t-10;\n\n\b\b\b\b" .. "x10" .."]" ..
 	"item_image_button[7.5,2.25;1,1;".. "currency:minegeld_5" ..";t-50;\n\n\b\b\b\b" .. "x10" .."]" ..
 	"item_image_button[8.5,2.25;1,1;".. "currency:minegeld_10" ..";t-100;\n\n\b\b\b\b" .. "x10" .."]" ..
 	"item_image_button[9.5,2.25;1,1;".. "currency:minegeld_50" ..";t-500;\n\n\b\b\b\b" .. "x10" .."]" ..
 	"item_image_button[10.5,2.25;1,1;".. "currency:minegeld_100" ..";t-1000;\n\n\b\b\b\b" .. "x10" .."]" ..
-	"item_image_button[0.5,3.25;1,1;".. "currency:minegeld" ..";c100;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[1.5,3.25;1,1;".. "currency:minegeld_5" ..";c500;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[2.5,3.25;1,1;".. "currency:minegeld_10" ..";c1000;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[3.5,3.25;1,1;".. "currency:minegeld_50" ..";c5000;\n\n\b\b\b" .. "x100" .."]" ..
-	"item_image_button[4.5,3.25;1,1;".. "currency:minegeld_100" ..";c10000;\n\n\b\b\b" .. "x100" .."]" ..
 	"item_image_button[6.5,3.25;1,1;".. "currency:minegeld" ..";c-100;\n\n\b\b\b" .. "x100" .."]" ..
 	"item_image_button[7.5,3.25;1,1;".. "currency:minegeld_5" ..";c-500;\n\n\b\b\b" .. "x100" .."]" ..
 	"item_image_button[8.5,3.25;1,1;".. "currency:minegeld_10" ..";c-1000;\n\n\b\b\b" .. "x100" .."]" ..

--- a/forms.lua
+++ b/forms.lua
@@ -1,63 +1,63 @@
 -- atm interface
 
 function atm.showform (player)
-    atm.ensure_init(player:get_player_name())
-    local formspec =
-    "size[12,8.5]"..
-    default.gui_bg..
-    default.gui_bg_img..
-    default.gui_slots..
-    "label[0.5,0;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
-    "label[0.5,0.35;Deposit:]" ..
-    "label[0.5,0.75;1s]" ..
-    "label[1.5,0.75;5s]" ..
-    "label[2.5,0.75;10s]" ..
-    "label[3.5,0.75;50s]" ..
-    "label[4.5,0.75;100s]" ..
+	atm.ensure_init(player:get_player_name())
+	local formspec =
+	"size[12,8.5]"..
+	default.gui_bg..
+	default.gui_bg_img..
+	default.gui_slots..
+	"label[0.5,0;Your account balance: $".. atm.balance[player:get_player_name()].. "]" ..
+	"label[0.5,0.35;Deposit:]" ..
+	"label[0.5,0.75;1s]" ..
+	"label[1.5,0.75;5s]" ..
+	"label[2.5,0.75;10s]" ..
+	"label[3.5,0.75;50s]" ..
+	"label[4.5,0.75;100s]" ..
 	"label[6.5,0.35;Withdraw:]" ..
-    "label[6.5,0.75;1s]" ..
-    "label[7.5,0.75;5s]" ..
-    "label[8.5,0.75;10s]" ..
-    "label[9.5,0.75;50s]" ..
-    "label[10.5,0.75;100s]" ..
-    "item_image_button[0.5,1.25;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[1.5,1.25;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[2.5,1.25;1,1;".. "currency:minegeld_10" ..";i10;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[3.5,1.25;1,1;".. "currency:minegeld_50" ..";i50;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[4.5,1.25;1,1;".. "currency:minegeld_100" ..";i100;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[6.5,1.25;1,1;".. "currency:minegeld" ..";i-1;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[7.5,1.25;1,1;".. "currency:minegeld_5" ..";i-5;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[8.5,1.25;1,1;".. "currency:minegeld_10" ..";i-10;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[9.5,1.25;1,1;".. "currency:minegeld_50" ..";i-50;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[10.5,1.25;1,1;".. "currency:minegeld_100" ..";i-100;\n\n\b\b\b\b\b" .. "x1" .."]" ..
-    "item_image_button[0.5,2.25;1,1;".. "currency:minegeld" ..";t10;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[1.5,2.25;1,1;".. "currency:minegeld_5" ..";t50;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[2.5,2.25;1,1;".. "currency:minegeld_10" ..";t100;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[3.5,2.25;1,1;".. "currency:minegeld_50" ..";t500;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[4.5,2.25;1,1;".. "currency:minegeld_100" ..";t1000;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[6.5,2.25;1,1;".. "currency:minegeld" ..";t-10;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[7.5,2.25;1,1;".. "currency:minegeld_5" ..";t-50;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[8.5,2.25;1,1;".. "currency:minegeld_10" ..";t-100;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[9.5,2.25;1,1;".. "currency:minegeld_50" ..";t-500;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[10.5,2.25;1,1;".. "currency:minegeld_100" ..";t-1000;\n\n\b\b\b\b" .. "x10" .."]" ..
-    "item_image_button[0.5,3.25;1,1;".. "currency:minegeld" ..";c100;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[1.5,3.25;1,1;".. "currency:minegeld_5" ..";c500;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[2.5,3.25;1,1;".. "currency:minegeld_10" ..";c1000;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[3.5,3.25;1,1;".. "currency:minegeld_50" ..";c5000;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[4.5,3.25;1,1;".. "currency:minegeld_100" ..";c10000;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[6.5,3.25;1,1;".. "currency:minegeld" ..";c-100;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[7.5,3.25;1,1;".. "currency:minegeld_5" ..";c-500;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[8.5,3.25;1,1;".. "currency:minegeld_10" ..";c-1000;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[9.5,3.25;1,1;".. "currency:minegeld_50" ..";c-5000;\n\n\b\b\b" .. "x100" .."]" ..
-    "item_image_button[10.5,3.25;1,1;".. "currency:minegeld_100" ..";c-10000;\n\n\b\b\b" .. "x100" .."]" ..
-    "button_exit[5.5,3;1,2;Quit;Quit]" ..
-    "list[current_player;main;2,4.5;8,1;]"..
-    "list[current_player;main;2,5.75;8,3;8]"..
-    "listring[]"..
-    default.get_hotbar_bg(2, 4.5)
-    minetest.after((0.1), function(gui)
-            return minetest.show_formspec(player:get_player_name(), "atm.form", gui)
-        end, formspec)
+	"label[6.5,0.75;1s]" ..
+	"label[7.5,0.75;5s]" ..
+	"label[8.5,0.75;10s]" ..
+	"label[9.5,0.75;50s]" ..
+	"label[10.5,0.75;100s]" ..
+	"item_image_button[0.5,1.25;1,1;".. "currency:minegeld" ..";i1;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[1.5,1.25;1,1;".. "currency:minegeld_5" ..";i5;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[2.5,1.25;1,1;".. "currency:minegeld_10" ..";i10;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[3.5,1.25;1,1;".. "currency:minegeld_50" ..";i50;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[4.5,1.25;1,1;".. "currency:minegeld_100" ..";i100;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[6.5,1.25;1,1;".. "currency:minegeld" ..";i-1;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[7.5,1.25;1,1;".. "currency:minegeld_5" ..";i-5;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[8.5,1.25;1,1;".. "currency:minegeld_10" ..";i-10;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[9.5,1.25;1,1;".. "currency:minegeld_50" ..";i-50;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[10.5,1.25;1,1;".. "currency:minegeld_100" ..";i-100;\n\n\b\b\b\b\b" .. "x1" .."]" ..
+	"item_image_button[0.5,2.25;1,1;".. "currency:minegeld" ..";t10;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[1.5,2.25;1,1;".. "currency:minegeld_5" ..";t50;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[2.5,2.25;1,1;".. "currency:minegeld_10" ..";t100;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[3.5,2.25;1,1;".. "currency:minegeld_50" ..";t500;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[4.5,2.25;1,1;".. "currency:minegeld_100" ..";t1000;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[6.5,2.25;1,1;".. "currency:minegeld" ..";t-10;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[7.5,2.25;1,1;".. "currency:minegeld_5" ..";t-50;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[8.5,2.25;1,1;".. "currency:minegeld_10" ..";t-100;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[9.5,2.25;1,1;".. "currency:minegeld_50" ..";t-500;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[10.5,2.25;1,1;".. "currency:minegeld_100" ..";t-1000;\n\n\b\b\b\b" .. "x10" .."]" ..
+	"item_image_button[0.5,3.25;1,1;".. "currency:minegeld" ..";c100;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[1.5,3.25;1,1;".. "currency:minegeld_5" ..";c500;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[2.5,3.25;1,1;".. "currency:minegeld_10" ..";c1000;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[3.5,3.25;1,1;".. "currency:minegeld_50" ..";c5000;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[4.5,3.25;1,1;".. "currency:minegeld_100" ..";c10000;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[6.5,3.25;1,1;".. "currency:minegeld" ..";c-100;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[7.5,3.25;1,1;".. "currency:minegeld_5" ..";c-500;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[8.5,3.25;1,1;".. "currency:minegeld_10" ..";c-1000;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[9.5,3.25;1,1;".. "currency:minegeld_50" ..";c-5000;\n\n\b\b\b" .. "x100" .."]" ..
+	"item_image_button[10.5,3.25;1,1;".. "currency:minegeld_100" ..";c-10000;\n\n\b\b\b" .. "x100" .."]" ..
+	"button_exit[5.5,3;1,2;Quit;Quit]" ..
+	"list[current_player;main;2,4.5;8,1;]"..
+	"list[current_player;main;2,5.75;8,3;8]"..
+	"listring[]"..
+	default.get_hotbar_bg(2, 4.5)
+	minetest.after((0.1), function(gui)
+			return minetest.show_formspec(player:get_player_name(), "atm.form", gui)
+		end, formspec)
 end
 
 

--- a/init.lua
+++ b/init.lua
@@ -3,12 +3,12 @@
 -- Large ATMs (C) 2017 Hans von Smacker
 
 atm = {
-  balance = {},
-  startbalance = 30,
-  pending_transfers = {},
-  completed_transactions = {},
-  pth = minetest.get_worldpath().."/atm_accounts",
-  pth_wt = minetest.get_worldpath().."/atm_wt_transactions"
+	balance = {},
+	startbalance = 30,
+	pending_transfers = {},
+	completed_transactions = {},
+	pth = minetest.get_worldpath().."/atm_accounts",
+	pth_wt = minetest.get_worldpath().."/atm_wt_transactions"
 }
 
 

--- a/receive_fields.lua
+++ b/receive_fields.lua
@@ -1,6 +1,7 @@
 
 -- Check the form
 
+-- only used for withdrawals
 minetest.register_on_player_receive_fields(function(player, form, pressed)
 
 	-- ATMs
@@ -10,7 +11,7 @@ minetest.register_on_player_receive_fields(function(player, form, pressed)
 		local pinv=player:get_inventory()
 
 		-- single note transactions
-		for _,i in pairs({1, 5, 10, 50, 100, -1, -5, -10, -50, -100}) do
+		for _,i in pairs({-1, -5, -10, -50, -100}) do
 			if pressed["i"..i] then
 				transaction.amount = i
 				transaction.denomination = '_' .. math.abs(i)
@@ -23,7 +24,7 @@ minetest.register_on_player_receive_fields(function(player, form, pressed)
 		end
 
 		-- 10x banknote transactions
-		for _,t in pairs({10, 50, 100, 500, 1000, -10, -50, -100, -500, -1000}) do
+		for _,t in pairs({-10, -50, -100, -500, -1000}) do
 			if pressed["t"..t] then
 				transaction.amount = t
 				transaction.denomination = '_' .. math.abs(t/10)
@@ -36,7 +37,7 @@ minetest.register_on_player_receive_fields(function(player, form, pressed)
 		end
 
 		-- 100x banknote transactions
-		for _,c in pairs({100, 500, 1000, 5000, 10000, -100, -500, -1000, -5000, -10000}) do
+		for _,c in pairs({-100, -500, -1000, -5000, -10000}) do
 			if pressed["c"..c] then
 				transaction.amount = c
 				transaction.denomination = '_' .. math.abs(c/100)

--- a/receive_fields_wt.lua
+++ b/receive_fields_wt.lua
@@ -28,15 +28,15 @@ minetest.register_on_player_receive_fields(function(player, form, pressed)
 				-- if passed, store the data in a temporary table and show confirmation window
 				if not atm.balance[pressed.dstn] then
 					minetest.chat_send_player(n, "The recepient <" .. pressed.dstn ..
-            "> is not registered in the banking system, aborting")
+						"> is not registered in the banking system, aborting")
 					atm.showform_wt(player)
 				elseif not string.match(pressed.amnt, '^[0-9]+$') then
 					minetest.chat_send_player(n, "Invalid amount <" .. pressed.amnt ..
-            "> : must be an integer number, aborting")
+						"> : must be an integer number, aborting")
 					atm.showform_wt(player)
 				elseif atm.balance[n] < tonumber(pressed.amnt) then
 					minetest.chat_send_player(n, "Your account does not have enough " ..
-            "funds to complete this transfer, aborting")
+						"funds to complete this transfer, aborting")
 					atm.showform_wt(player)
 				else
 					atm.pending_transfers[n] = {to = pressed.dstn, sum = tonumber(pressed.amnt), desc = pressed.desc}


### PR DESCRIPTION
<del>***Edit:** You may want to wait to merge. Read below.*</del>

Changes formspec so that players can simply drag money from inventory & drop it into account. Retains pressing buttons for withdrawals.

![atm_drag_and_drop](https://user-images.githubusercontent.com/3631473/118699748-c0bdbd80-b7c6-11eb-9ab2-306a4de0b768.png)

Other changes:
- <del>Formspec is updated using meta info instead of `core.show_formspec`.</del>
- Made all leading whitespace in source match by converting spaces to tabs.
- Made button labels independent of buttons  which allows them to be positioned so they don't get clipped with larger fonts.

<del>**Edit:** When using meta data to set & display the formspec, there is an issue with it not displaying the first time you click it after the server is restarted. I believe this is due to a bug in Minetest. The only way around it is to set the formspec under the *on_construct* callback. However, I don't think that is wise for this mod because we need to get the player information before it is shown. We need to use the meta data method to catch when an item is dropped into the deposit box. There may be a different fix. I will keep looking around.</del>

<del>**Edit:** There is another issue that causes the player's active formspec to change if another player clicks on the machine. It changes to show the balance of the second player. Fortunately, any changes made affect only the owning player's account. But still an issue. I'm trying to find a fix.</del>

**Edit:** Changed to use detached inventory instead of node meta so that players cannot interfere with each others' transactions.